### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "standard": "^17.1.0"
   },
   "dependencies": {
-    "bip39-mnemonic": "^2.2.0",
     "b4a": "^1.6.4",
-    "compact-encoding": "^2.13.0",
+    "bip39-mnemonic": "^2.2.0",
+    "compact-encoding": "^3.0.0",
     "nanoassert": "^2.0.0",
     "sodium-hmac": "^2.0.1",
     "sodium-universal": "^5.0.1"


### PR DESCRIPTION
Doesn't use `buffer` or `binary` so is just a bump.